### PR TITLE
Counting cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist-newstyle
 result
 .stack-work
 stack.yaml.lock
+.direnv
+.envrc

--- a/osl.cabal
+++ b/osl.cabal
@@ -130,6 +130,7 @@ library
     OSL.Value
     OSL.Witness
     Semicircuit.Argument
+    Semicircuit.CountCases
     Semicircuit.DNFFormula
     Semicircuit.Gensyms
     Semicircuit.PrenexNormalForm

--- a/src/OSL/Types/Cardinality.hs
+++ b/src/OSL/Types/Cardinality.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module OSL.Types.Cardinality (Cardinality (..)) where
+module OSL.Types.Cardinality (Cardinality (..), cardinalityToInteger) where
 
 -- The maximum number of elements of a collection type.
 newtype Cardinality = Cardinality Integer
   deriving newtype (Eq, Ord, Show, Num)
+
+cardinalityToInteger :: Cardinality -> Integer
+cardinalityToInteger (Cardinality c) = c

--- a/src/OSL/Types/ErrorMessage.hs
+++ b/src/OSL/Types/ErrorMessage.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module OSL.Types.ErrorMessage (ErrorMessage (ErrorMessage)) where
 
@@ -10,3 +11,9 @@ data ErrorMessage ann = ErrorMessage
     message :: Text
   }
   deriving (Eq, Ord, Generic, Show)
+
+instance Semigroup a => Semigroup (ErrorMessage a) where
+  (ErrorMessage a1 m1) <> (ErrorMessage a2 m2) = ErrorMessage (a1 <> a2) (m1 <> " | " <> m2)
+
+instance Monoid a => Monoid (ErrorMessage a) where
+  mempty = mempty

--- a/src/Semicircuit/CountCases.hs
+++ b/src/Semicircuit/CountCases.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+
+module Semicircuit.CountCases
+  ( countCases
+  ) where
+
+
+import Die (die)
+import OSL.Types.ErrorMessage (ErrorMessage)
+import Semicircuit.Types.Semicircuit (Semicircuit)
+import Trace.Types (NumberOfCases)
+
+
+countCases :: Semicircuit -> Either (ErrorMessage ()) NumberOfCases
+countCases = todo
+
+
+todo :: a
+todo = die "todo"

--- a/src/Semicircuit/CountCases.hs
+++ b/src/Semicircuit/CountCases.hs
@@ -8,7 +8,7 @@ where
 
 import Control.Lens ((^.))
 import Data.Bifunctor (second)
-import Data.Either.Combinators (maybeToRight)
+import Data.Either (fromRight, partitionEithers)
 import Data.Foldable (foldl')
 import qualified Data.Map as Map
 import qualified Data.Set as Set
@@ -16,45 +16,68 @@ import OSL.Sigma11 (evalTerm)
 import OSL.Types.Cardinality (cardinalityToInteger)
 import OSL.Types.ErrorMessage (ErrorMessage (..))
 import OSL.Types.Sigma11.EvaluationContext (EvaluationContextF (..))
+import OSL.Types.Sigma11.Value (Value (Value))
 import Semicircuit.Types.PNFFormula (Quantifiers (..), UniversalQuantifier (..))
 import Semicircuit.Types.Semicircuit (FreeVariables (..), Semicircuit (..))
-import Semicircuit.Types.Sigma11 (ExistentialQuantifier, InstanceQuantifier)
-import Stark.Types.Scalar (Scalar, fromWord64, toWord64)
+import Semicircuit.Types.Sigma11 (EvaluationContext, ExistentialQuantifier, InstanceQuantifier)
+import Stark.Types.Scalar (fromWord64, toWord64, zero)
 import Trace.Types (NumberOfCases (..))
 
-countUniversal :: UniversalQuantifier -> Integer
-countUniversal (All _ bound) = f evaluated
-  where
-    emptyContext = EvaluationContext Map.empty
-    evaluated = evalTerm emptyContext bound
-    f :: Either (ErrorMessage ()) Scalar -> Integer
-    f (Left _) = 0 -- TODO: what do I really want here?
-    f (Right s) = toInteger $ toWord64 s
+type CountResult = Either (ErrorMessage ()) Integer
 
-countUniversals :: [UniversalQuantifier] -> Integer
-countUniversals = foldl' (*) 1 . map countUniversal
+countUniversal :: EvaluationContext -> UniversalQuantifier -> CountResult
+countUniversal evalctx (All _ bound) = second (toInteger . toWord64) $ evalTerm evalctx bound
+
+countUniversalInit :: UniversalQuantifier -> CountResult
+countUniversalInit = countUniversal $ EvaluationContext Map.empty
+
+countUniversals' :: EvaluationContext -> [UniversalQuantifier] -> [CountResult]
+countUniversals' _ [] = []
+countUniversals' _ [x] = [countUniversalInit x]
+countUniversals' (EvaluationContext ctx) (x : xs) = countUniversal ctx' x : countUniversals' ctx' xs
+  where
+    ctx' = EvaluationContext $ Map.union ctx $ Map.fromList [(k, v)]
+    k = Left $ x ^. #name
+    v = Value $ Map.fromList [([], fromRight zero $ evalTerm (EvaluationContext ctx) (x ^. #bound))]
+
+countUniversals :: [UniversalQuantifier] -> CountResult
+countUniversals uqs
+  | null errors = Right value
+  | otherwise = Left e
+  where
+    results = countUniversals' (EvaluationContext Map.empty) uqs
+    (errors, values) = partitionEithers results
+    e = mconcat errors
+    value = foldl' (*) 1 values
 
 countExistential :: ExistentialQuantifier -> Integer
 countExistential = cardinalityToInteger . flip (^.) #cardinality
 
 countExistentials :: [ExistentialQuantifier] -> Integer
-countExistentials = foldl' (+) 0 . map countExistential
+countExistentials = foldl' max 0 . map countExistential
 
 countInstance :: InstanceQuantifier -> Integer
 countInstance = cardinalityToInteger . flip (^.) #cardinality
 
 countInstances :: [InstanceQuantifier] -> Integer
-countInstances = foldl' (+) 0 . map countInstance
+countInstances = foldl' max 0 . map countInstance
+
+eithMaybToEith :: a -> Either a (Maybe b) -> Either a b
+eithMaybToEith _ (Left x) = Left x
+eithMaybToEith l (Right x) = case x of
+  Nothing -> Left l
+  Just x' -> Right x'
 
 countCases :: Semicircuit -> Either (ErrorMessage ()) NumberOfCases
 countCases (Semicircuit (FreeVariables fv) f)
-  | Set.null fv = second NumberOfCases $ maybeToRight (ErrorMessage () "Number of cases overflow") (fromWord64 numRows)
+  | Set.null fv = second NumberOfCases numRows
   | otherwise = Left $ ErrorMessage () "Nonempty free variables"
   where
+    overflowErrMsg = ErrorMessage () "Number of cases overflowed"
     qs = f ^. #quantifiers
-    x, y, z :: Quantifiers -> Integer
     x = countUniversals . flip (^.) #universalQuantifiers
+    y, z :: Quantifiers -> Integer
     y = countExistentials . flip (^.) #existentialQuantifiers
     z = countInstances . flip (^.) #instanceQuantifiers
-    numRows' = x qs + y qs + z qs
-    numRows = toWord64 $ fromInteger numRows'
+    numRows' = Right ((y qs `max` z qs) +) <*> x qs
+    numRows = eithMaybToEith overflowErrMsg $ second (fromWord64 . toWord64 . fromInteger) numRows'

--- a/src/Semicircuit/CountCases.hs
+++ b/src/Semicircuit/CountCases.hs
@@ -1,20 +1,60 @@
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-
 module Semicircuit.CountCases
-  ( countCases
-  ) where
+  ( countCases,
+  )
+where
 
+import Control.Lens ((^.))
+import Data.Either.Combinators (maybeToRight)
+import Data.Foldable (foldl')
+import Data.Bifunctor (second)
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import OSL.Sigma11 (evalTerm)
+import OSL.Types.Cardinality (cardinalityToInteger)
+import OSL.Types.ErrorMessage (ErrorMessage (..))
+import OSL.Types.Sigma11.EvaluationContext (EvaluationContextF (..))
+import Semicircuit.Types.PNFFormula (Quantifiers (..), UniversalQuantifier (..))
+import Semicircuit.Types.Semicircuit (FreeVariables (..), Semicircuit (..))
+import Semicircuit.Types.Sigma11 (ExistentialQuantifier, InstanceQuantifier)
+import Stark.Types.Scalar (Scalar, fromWord64, toWord64)
+import Trace.Types (NumberOfCases (..))
 
-import Die (die)
-import OSL.Types.ErrorMessage (ErrorMessage)
-import Semicircuit.Types.Semicircuit (Semicircuit)
-import Trace.Types (NumberOfCases)
+countUniversal :: UniversalQuantifier -> Integer
+countUniversal (All _ bound) = f evaluated
+  where
+    emptyContext = EvaluationContext Map.empty
+    evaluated = evalTerm emptyContext bound
+    f :: Either (ErrorMessage ()) Scalar -> Integer
+    f (Left _) = 0 -- TODO: what do I really want here?
+    f (Right s) = toInteger $ toWord64 s
 
+countUniversals :: [UniversalQuantifier] -> Integer
+countUniversals = foldl' (*) 1 . map countUniversal
+
+countExistential :: ExistentialQuantifier -> Integer
+countExistential = cardinalityToInteger . flip (^.) #cardinality
+
+countExistentials :: [ExistentialQuantifier] -> Integer
+countExistentials = foldl' (+) 0 . map countExistential
+
+countInstance :: InstanceQuantifier -> Integer
+countInstance = cardinalityToInteger . flip (^.) #cardinality
+
+countInstances :: [InstanceQuantifier] -> Integer
+countInstances = foldl' (+) 0 . map countInstance
 
 countCases :: Semicircuit -> Either (ErrorMessage ()) NumberOfCases
-countCases = todo
-
-
-todo :: a
-todo = die "todo"
+countCases (Semicircuit (FreeVariables fv) f)
+  | Set.null fv = second NumberOfCases $ maybeToRight (ErrorMessage () "Number of cases overflow") (fromWord64 numRows)
+  | otherwise = Left $ ErrorMessage () "Nonempty free variables"
+  where
+    qs = f ^. #quantifiers
+    x, y, z :: Quantifiers -> Integer
+    x = countUniversals . flip (^.) #universalQuantifiers
+    y = countExistentials . flip (^.) #existentialQuantifiers
+    z = countInstances . flip (^.) #instanceQuantifiers
+    numRows' = x qs + y qs + z qs
+    numRows = toWord64 $ fromInteger numRows'

--- a/src/Semicircuit/CountCases.hs
+++ b/src/Semicircuit/CountCases.hs
@@ -7,9 +7,9 @@ module Semicircuit.CountCases
 where
 
 import Control.Lens ((^.))
+import Data.Bifunctor (second)
 import Data.Either.Combinators (maybeToRight)
 import Data.Foldable (foldl')
-import Data.Bifunctor (second)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import OSL.Sigma11 (evalTerm)


### PR DESCRIPTION
- I inferred from mattermost discussion that the empty `EvaluationContext` is the solution to `evalTerm`'s type signature (in `countUniversal`) 
- But I don't know what `evalTerm empty bound => Left _` means really, so I just set it to `0` so I could move on with my life. Do you want me to bubble up the error to `countCases`? 
- Is what I did to `Cardinality.hs` smelly? I added an unwrapper `Cardinality -> Integer`